### PR TITLE
Backend address variable

### DIFF
--- a/compose-with-db.yaml
+++ b/compose-with-db.yaml
@@ -3,6 +3,9 @@ services:
     build:
       context: ./frontend
     restart: always
+    command: sh -c "echo $$BACKEND_ADDRESS > /.env.local && exec original-command"
+    environment:
+      - BACKEND_ADDRESS='http://backend:80/'
     depends_on:
       - backend
     ports:

--- a/compose-with-db.yaml
+++ b/compose-with-db.yaml
@@ -3,7 +3,6 @@ services:
     build:
       context: ./frontend
     restart: always
-    command: sh -c "echo $$BACKEND_ADDRESS > /.env.local && exec original-command"
     environment:
       - BACKEND_ADDRESS='http://backend:80/'
     depends_on:

--- a/compose-with-db.yaml
+++ b/compose-with-db.yaml
@@ -4,7 +4,7 @@ services:
       context: ./frontend
     restart: always
     environment:
-      - BACKEND_ADDRESS='http://backend:80/'
+      - BACKEND_ADDRESS=http://backend:80/
     depends_on:
       - backend
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,30 +1,20 @@
-# Use the official Node.js image as the base
 FROM node:20-alpine
 
-# Set the working directory inside the container
 WORKDIR /src/app
 
-# Copy package.json and package-lock.json to the working directory
 COPY package*.json ./
 
-# Disable Next.js default telemetry
-RUN npx next telemetry disable
+RUN npx next telemetry disable && \
+    npm ci
 
-# Install dependencies
-RUN npm ci
-
-# Copy the entire project to the working directory
 COPY . .
 
-# Build the Next.js application
 RUN npm run build
 
-# Expose the port on which the application will run (default is 3000)
 EXPOSE 3000
 
-RUN chmod -R +x /scripts
+RUN chmod -R +x ../../scripts
 
 ENV PATH="/scripts:$PATH"
 
-# Start the Next.js application
 CMD ["run.sh"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,6 +17,6 @@ COPY ../../scripts ./scripts
 
 RUN chmod -R +x ./scripts
 
-ENV PATH="/scripts:$PATH"
+ENV PATH="./scripts:$PATH"
 
 CMD ["run.sh"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,7 +13,9 @@ RUN npm run build
 
 EXPOSE 3000
 
-RUN chmod -R +x ../../scripts
+COPY ../../scripts ./scripts
+
+RUN chmod -R +x /scripts
 
 ENV PATH="/scripts:$PATH"
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,7 +15,7 @@ EXPOSE 3000
 
 COPY ../../scripts ./scripts
 
-RUN chmod -R +x /scripts
+RUN chmod -R +x ./scripts
 
 ENV PATH="/scripts:$PATH"
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -22,5 +22,9 @@ RUN npm run build
 # Expose the port on which the application will run (default is 3000)
 EXPOSE 3000
 
+RUN chmod -R +x /scripts
+
+ENV PATH="/scripts:$PATH"
+
 # Start the Next.js application
-CMD ["npm", "start"]
+CMD ["run.sh"]

--- a/frontend/scripts/run.sh
+++ b/frontend/scripts/run.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-env > /.env.local
+env > .env.local
 
 npm start

--- a/frontend/scripts/run.sh
+++ b/frontend/scripts/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+env > /.env.local
+
+npm start

--- a/frontend/src/app/components/claimbox.tsx
+++ b/frontend/src/app/components/claimbox.tsx
@@ -1,9 +1,16 @@
+import { unstable_noStore as noStore } from 'next/cache';
+
 export default async function Claimbox() {
+  noStore();
   let responseText = ''; // Initialize variable to store raw response text
 
   try {
-    const response = await fetch('http://backend', { cache: 'no-store' });
-    responseText = await response.text();
+    if (typeof process.env.BACKEND_ADDRESS === 'undefined') {
+      throw new Error("BACKEND_ADDRESS has type 'undefined'");
+    } else {
+      const response = await fetch(process.env.BACKEND_ADDRESS, { cache: 'no-store' });
+      responseText = await response.text();
+    }
   } catch (error) {
     return <div>Error</div>;
   }


### PR DESCRIPTION
We can now specify the address of the backend in the compose-with-db.yaml file. I like this setup because I don't want details of how the backend is configured cluttering up my frontend codebase. 