### PR TITLE
Let's restrict the interface of claims-context.tsx so that other parts of the code can't break the data invariants.

### DIFF
--- a/frontend/src/app/_components/claim-box.tsx
+++ b/frontend/src/app/_components/claim-box.tsx
@@ -52,7 +52,7 @@ function ClaimContentBox({claim, hasDefinitions}: {claim: Claim, hasDefinitions:
   const [editing, setEditing] = useState(false);
   const textRef = useRef<HTMLParagraphElement>(null);
   const { setClaimText, getDisplayData } = useClaimsContext();
-  const [validText, setValidText] = useState(getDisplayData(claim).validText);
+  const { validText, displayText } = getDisplayData(claim);
 
   useEffect(() => {
     if (editing && textRef.current !== null) {
@@ -63,7 +63,6 @@ function ClaimContentBox({claim, hasDefinitions}: {claim: Claim, hasDefinitions:
   const handleBlur = () => {
     setEditing(false);
     setClaimText({claimID: claim.claimID, newText: text});
-    setValidText(getDisplayData({...claim, text:text}).validText);
   }
 
   return (
@@ -78,7 +77,7 @@ function ClaimContentBox({claim, hasDefinitions}: {claim: Claim, hasDefinitions:
           {claim.text}
         </p>) :
         (<p className="w-full h-full p-2" onClick={() => setEditing(true)}>
-          {getDisplayData(claim).displayText}
+          {displayText}
         </p>)
       }
       {(!validText && editing) ?

--- a/frontend/src/app/_components/new-claim-button.tsx
+++ b/frontend/src/app/_components/new-claim-button.tsx
@@ -4,44 +4,8 @@ import { Menu } from '@headlessui/react'
 import { useClaimsContext } from '@/app/_contexts/claims-context';
 
 export function NewClaimButton() {
-  const { newClaimID, addClaim } = useClaimsContext();
+  const { addClaim } = useClaimsContext();
 
-  const addTextClaim = () => {
-    const claimID = newClaimID();
-    addClaim({
-      claimID: claimID,
-      author: 'local',
-      claimType: 'text' as const,
-      text: '',
-      dependencies: new Set<string>(),
-      definitionClaimIDs: [],
-    });
-  }
-  
-  const addDefinitionClaim = () => {
-    const claimID = newClaimID();
-    addClaim({
-      claimID: claimID,
-      author: 'local',
-      claimType: 'definition' as const,
-      text: '',
-      dependencies: new Set<string>(),
-      definitionClaimIDs: [],
-    });
-  }
-
-  const addZerothOrderClaim = () => {
-    const claimID = newClaimID();
-    addClaim({
-      claimID: claimID,
-      author: 'local',
-      claimType: 'zeroth-order' as const,
-      text: '',
-      dependencies: new Set<string>(),
-      parse: null,
-    });
-  }
-  
   return (
     <div className="relative">
       <Menu>
@@ -58,7 +22,7 @@ export function NewClaimButton() {
               {({ active }) => (
                 <a
                   className={`block px-4 py-2 rounded-t-md ${active ? 'bg-bright-text' : 'bg-medium-text'}`}
-                  onClick={addTextClaim}>
+                  onClick={addClaim({author: 'local', claimType: 'text' as const, text: ''})}>
                   Text Claim
                 </a>
               )}
@@ -67,7 +31,7 @@ export function NewClaimButton() {
               {({ active }) => (
                 <a
                   className={`block px-4 py-2 ${active ? 'bg-bright-definition' : 'bg-medium-definition'}`}
-                  onClick={addDefinitionClaim}>
+                  onClick={addClaim({author: 'local', claimType: 'definition' as const, text: ''})}>
                   Definition Claim
                 </a>
               )}
@@ -76,7 +40,7 @@ export function NewClaimButton() {
               {({ active }) => (
                 <a
                   className={`block px-4 py-2 rounded-b-md ${active ? 'bg-bright-zeroth-order' : 'bg-medium-zeroth-order'}`}
-                  onClick={addZerothOrderClaim}>
+                  onClick={addClaim({author: 'local', claimType: 'zeroth-order' as const, text: ''})}>
                   Zeroth Order Claim
                 </a>
               )}

--- a/frontend/src/app/_components/new-claim-button.tsx
+++ b/frontend/src/app/_components/new-claim-button.tsx
@@ -22,7 +22,7 @@ export function NewClaimButton() {
               {({ active }) => (
                 <a
                   className={`block px-4 py-2 rounded-t-md ${active ? 'bg-bright-text' : 'bg-medium-text'}`}
-                  onClick={addClaim({author: 'local', claimType: 'text' as const, text: ''})}>
+                  onClick={() => addClaim({author: 'local', claimType: 'text' as const, text: ''})}>
                   Text Claim
                 </a>
               )}
@@ -31,7 +31,7 @@ export function NewClaimButton() {
               {({ active }) => (
                 <a
                   className={`block px-4 py-2 ${active ? 'bg-bright-definition' : 'bg-medium-definition'}`}
-                  onClick={addClaim({author: 'local', claimType: 'definition' as const, text: ''})}>
+                  onClick={() => addClaim({author: 'local', claimType: 'definition' as const, text: ''})}>
                   Definition Claim
                 </a>
               )}
@@ -40,7 +40,7 @@ export function NewClaimButton() {
               {({ active }) => (
                 <a
                   className={`block px-4 py-2 rounded-b-md ${active ? 'bg-bright-zeroth-order' : 'bg-medium-zeroth-order'}`}
-                  onClick={addClaim({author: 'local', claimType: 'zeroth-order' as const, text: ''})}>
+                  onClick={() => addClaim({author: 'local', claimType: 'zeroth-order' as const, text: ''})}>
                   Zeroth Order Claim
                 </a>
               )}

--- a/frontend/src/app/_contexts/claims-context.tsx
+++ b/frontend/src/app/_contexts/claims-context.tsx
@@ -51,10 +51,10 @@ export function ClaimsContextProvider({ children }: { children: React.ReactNode 
       }
       attempts += 1;
     } while (
-      (claimLookup.hasOwnProperty(uniqueID) || !potentialClaimID(uniqueID))
+      (claimLookup.hasOwnProperty(uniqueID) || !potentialClaimID({candidate: uniqueID}))
       && (attempts < 100)
     );
-    if (claimLookup.hasOwnProperty(uniqueID) || !potentialClaimID(uniqueID)) {
+    if (claimLookup.hasOwnProperty(uniqueID) || !potentialClaimID({candidate: uniqueID})) {
       throw new Error("Unable to generate new claimID");
     }
     return uniqueID;

--- a/frontend/src/app/_contexts/claims-context.tsx
+++ b/frontend/src/app/_contexts/claims-context.tsx
@@ -90,6 +90,7 @@ export function ClaimsContextProvider({ children }: { children: React.ReactNode 
       setClaimLookup(prevLookup => ({ ...prevLookup, [claimID]: claim }));
       setClaimIDs(prevIDs => [claimID,].concat(prevIDs));
     } else {const exhaustive: never = claimType;}
+    return claimID;
   };
 
   const moveClaim = ({startClaimID, endClaimID}:

--- a/frontend/src/app/_contexts/claims-context.tsx
+++ b/frontend/src/app/_contexts/claims-context.tsx
@@ -66,19 +66,22 @@ export function ClaimsContextProvider({ children }: { children: React.ReactNode 
   const addClaim = ({author, claimType, text}:
     {author: string, claimType: 'text'|'definition'|'zeroth-order', text: string}) => {
     const claimID = newClaimID();
+    const claim = {
+      claimID: claimID,
+      author: author,
+      claimType: claimType,
+      text: text,
+    };
     if (claimType === 'text' || claimType === 'definition') {
-      const claim = {
-        claimID: claimID,
-        author: author,
-        claimType: claimType,
-        text: text,
-        dependencies: new Set<string>(),
-        definitionClaimIDs: [] as string[],
-      } 
-      setClaimLookup(prevLookup => ({ ...prevLookup, [claimID]: claim }));
-      setClaimIDs(prevIDs => [claimID,].concat(prevIDs));
-    } else if (claimType === 'zeroth-order') {
+      claim['dependencies'] = new Set<string>();
+      claim['definitionClaimIDs'] = [] as string[];
+    } else if (claimType === 'zeroth-order') { 
+      const parse = parseFormula({formula: text});
+      claim['parse'] = parse;
+      claim['dependencies'] = immediateConstraintDependencies({parse: parse});
     } else {const exhaustive: never = claimType;}
+    setClaimLookup(prevLookup => ({ ...prevLookup, [claimID]: claim as Claim }));
+    setClaimIDs(prevIDs => [claimID,].concat(prevIDs));
   };
 
   const moveClaim = ({startClaimID, endClaimID}:

--- a/frontend/src/app/_contexts/claims-context.tsx
+++ b/frontend/src/app/_contexts/claims-context.tsx
@@ -99,7 +99,11 @@ export function ClaimsContextProvider({ children }: { children: React.ReactNode 
 
   const attachBlankDefinition = (claim: ClaimWithDefinitions) => {
     const newDefinitionClaimIDs = ['',].concat(claim.definitionClaimIDs);
-    const updatedClaim = { ...claim, definitionClaimIDs: newDefinitionClaimIDs };
+    const updatedClaim = {
+      ...claim,
+      definitionClaimIDs: newDefinitionClaimIDs,
+      dependencies: Set(newDefinitionClaimIDs),
+    };
     setClaimLookup(prevClaimLookup => {return { ...prevClaimLookup, [claim.claimID]: updatedClaim };});
   };
   

--- a/frontend/src/app/_contexts/claims-context.tsx
+++ b/frontend/src/app/_contexts/claims-context.tsx
@@ -144,6 +144,10 @@ export function ClaimsContextProvider({ children }: { children: React.ReactNode 
       if (!(claimID in prevClaimLookup))
         {throw new Error("Editing unrecognized claim");}
       const updatedClaim = { ...prevClaimLookup[claimID], text: newText};
+      if (updatedClaim.claimType === 'zeroth-order') {
+        updatedClaim.parse = parseFormula({formula: newText});
+        updatedClaim.dependencies = immediateConstraintDependencies({parse: updatedClaim.parse});
+      }
       return { ...prevClaimLookup, [claimID]: updatedClaim };
     });
   }

--- a/frontend/src/app/_contexts/claims-context.tsx
+++ b/frontend/src/app/_contexts/claims-context.tsx
@@ -73,12 +73,11 @@ export function ClaimsContextProvider({ children }: { children: React.ReactNode 
       text: text,
     };
     if (claimType === 'text' || claimType === 'definition') {
-      claim['dependencies'] = new Set<string>();
-      claim['definitionClaimIDs'] = [] as string[];
+      claim.dependencies = new Set<string>();
+      claim.definitionClaimIDs: string[] = [];
     } else if (claimType === 'zeroth-order') { 
-      const parse = parseFormula({formula: text});
-      claim['parse'] = parse;
-      claim['dependencies'] = immediateConstraintDependencies({parse: parse});
+      claim.parse = parseFormula({formula: text});
+      claim.dependencies = immediateConstraintDependencies({parse: claim.parse});
     } else {const exhaustive: never = claimType;}
     setClaimLookup(prevLookup => ({ ...prevLookup, [claimID]: claim as Claim }));
     setClaimIDs(prevIDs => [claimID,].concat(prevIDs));

--- a/frontend/src/app/_contexts/claims-context.tsx
+++ b/frontend/src/app/_contexts/claims-context.tsx
@@ -163,7 +163,10 @@ export function ClaimsContextProvider({ children }: { children: React.ReactNode 
       const updatedClaim = { ...prevClaimLookup[claimID], text: newText};
       if (updatedClaim.claimType === 'zeroth-order') {
         updatedClaim.parse = parseFormula({formula: newText});
-        updatedClaim.dependencies = immediateConstraintDependencies({parse: updatedClaim.parse});
+        updatedClaim.dependencies = 
+          (updatedClaim.parse !== null) ?
+          immediateConstraintDependencies({parse: updatedClaim.parse}) :
+          new Set<string>();
       }
       return { ...prevClaimLookup, [claimID]: updatedClaim };
     });

--- a/frontend/src/app/_contexts/claims-context.tsx
+++ b/frontend/src/app/_contexts/claims-context.tsx
@@ -11,8 +11,8 @@ import { displayConstraintParse } from '@/app/_contexts/display-constraint-parse
 type ClaimsContext = {
   claimLookup: { [claimID: string]: Claim };
   claimIDs: string[]; //used for storing the order in which the claims are displayed
-  setClaimLookup: React.Dispatch<React.SetStateAction<{ [claimID: string]: Claim }>>;
-  setClaimIDs: React.Dispatch<React.SetStateAction<string[]>>;
+  //I don't return the setClaimLookup or setClaimIDs functions so that
+  //other parts of the code can't break the data invariants.
   
   newClaimID: () => string;
   
@@ -174,8 +174,6 @@ export function ClaimsContextProvider({ children }: { children: React.ReactNode 
       value={{
         claimLookup,
         claimIDs,
-        setClaimLookup,
-        setClaimIDs,
 
         newClaimID,
 

--- a/frontend/src/app/_contexts/claims-context.tsx
+++ b/frontend/src/app/_contexts/claims-context.tsx
@@ -165,9 +165,9 @@ export function ClaimsContextProvider({ children }: { children: React.ReactNode 
   const getDisplayData = (claim: Claim) => {
     if (claim.claimType !== 'zeroth-order')
       {return {displayText: getInterpretedText(claim), validText: true};}
-    const parse = parseFormula({formula: claim.text});
-    if (parse === null) {return {displayText: "Please enter a valid constraint.", validText: false};}
-    const referencedIDs = Array.from(immediateConstraintDependencies({parse: parse}));
+    if (claim.parse === null)
+      {return {displayText: "Please enter a valid constraint.", validText: false};}
+    const referencedIDs = Array.from(claim.dependencies);
     let substitutions: { [claimID: string]: string} = {};
     for (let i = 0; i < referencedIDs.length; i++) {
       if (!(referencedIDs[i] in claimLookup)) {

--- a/frontend/src/app/_contexts/claims-context.tsx
+++ b/frontend/src/app/_contexts/claims-context.tsx
@@ -63,21 +63,33 @@ export function ClaimsContextProvider({ children }: { children: React.ReactNode 
   const addClaim = ({author, claimType, text}:
     {author: string, claimType: 'text'|'definition'|'zeroth-order', text: string}) => {
     const claimID = newClaimID();
-    const claim = {
-      claimID: claimID,
-      author: author,
-      claimType: claimType,
-      text: text,
-    };
     if (claimType === 'text' || claimType === 'definition') {
-      claim.dependencies = new Set<string>();
-      claim.definitionClaimIDs: string[] = [];
-    } else if (claimType === 'zeroth-order') { 
-      claim.parse = parseFormula({formula: text});
-      claim.dependencies = immediateConstraintDependencies({parse: claim.parse});
+      const claim = {
+        claimID: claimID,
+        author: author,
+        claimType: claimType,
+        text: text,
+        dependencies: new Set<string>(),
+        definitionClaimIDs: [] as string[],
+      } as Claim;
+      setClaimLookup(prevLookup => ({ ...prevLookup, [claimID]: claim }));
+      setClaimIDs(prevIDs => [claimID,].concat(prevIDs));
+    } else if (claimType === 'zeroth-order') {
+      const parse = parseFormula({formula: text});
+      const claim = {
+        claimID: claimID,
+        author: author,
+        claimType: claimType,
+        text: text,
+        dependencies:
+          (parse !== null) ?
+          immediateConstraintDependencies({parse: parse}) :
+          new Set<string>(),
+        parse: parse,
+      } as Claim;
+      setClaimLookup(prevLookup => ({ ...prevLookup, [claimID]: claim }));
+      setClaimIDs(prevIDs => [claimID,].concat(prevIDs));
     } else {const exhaustive: never = claimType;}
-    setClaimLookup(prevLookup => ({ ...prevLookup, [claimID]: claim as Claim }));
-    setClaimIDs(prevIDs => [claimID,].concat(prevIDs));
   };
 
   const moveClaim = ({startClaimID, endClaimID}:

--- a/frontend/src/app/_contexts/claims-context.tsx
+++ b/frontend/src/app/_contexts/claims-context.tsx
@@ -111,7 +111,7 @@ export function ClaimsContextProvider({ children }: { children: React.ReactNode 
     const updatedClaim = {
       ...claim,
       definitionClaimIDs: newDefinitionClaimIDs,
-      dependencies: Set(newDefinitionClaimIDs),
+      dependencies: new Set(newDefinitionClaimIDs),
     };
     setClaimLookup(prevClaimLookup => {return { ...prevClaimLookup, [claim.claimID]: updatedClaim };});
   };
@@ -134,7 +134,7 @@ export function ClaimsContextProvider({ children }: { children: React.ReactNode 
     const updatedClaim = {
       ...claim,
       definitionClaimIDs: newDefinitionClaimIDs,
-      dependencies: Set(newDefinitionClaimIDs),
+      dependencies: new Set(newDefinitionClaimIDs),
     };
     setClaimLookup(prevClaimLookup => {return { ...prevClaimLookup, [claim.claimID]: updatedClaim };});
   };
@@ -201,7 +201,7 @@ export function ClaimsContextProvider({ children }: { children: React.ReactNode 
       }
       substitutions[referencedIDs[i]] = getInterpretedText(claimLookup[referencedIDs[i]]);
     }
-    const displayText = displayConstraintParse({parse: parse, substitutions: substitutions});
+    const displayText = displayConstraintParse({parse: claim.parse, substitutions: substitutions});
     return {displayText: displayText, validText: true};
   }
 

--- a/frontend/src/app/_contexts/claims-context.tsx
+++ b/frontend/src/app/_contexts/claims-context.tsx
@@ -121,8 +121,12 @@ export function ClaimsContextProvider({ children }: { children: React.ReactNode 
  
     let newDefinitionClaimIDs = [ ...claim.definitionClaimIDs ];
     if (deleteAttachment) {newDefinitionClaimIDs.splice(index, 1);}
-      else {newDefinitionClaimIDs[index] = newDefinitionClaimID;}
-    const updatedClaim = { ...claim, definitionClaimIDs: newDefinitionClaimIDs };
+    else {newDefinitionClaimIDs[index] = newDefinitionClaimID;}
+    const updatedClaim = {
+      ...claim,
+      definitionClaimIDs: newDefinitionClaimIDs,
+      dependencies: Set(newDefinitionClaimIDs),
+    };
     setClaimLookup(prevClaimLookup => {return { ...prevClaimLookup, [claim.claimID]: updatedClaim };});
   };
 

--- a/frontend/src/app/_contexts/claims-context.tsx
+++ b/frontend/src/app/_contexts/claims-context.tsx
@@ -3,7 +3,7 @@
 //Credit to the tutorial at https://www.youtube.com/watch?v=I7dwJxGuGYQ for the template!
 
 import { createContext, useContext, useState } from 'react';
-import { Claim, ClaimWithDefinitions } from '@/app/_types/claim-types';
+import { Claim, ClaimWithDefinitions, potentialClaimID } from '@/app/_types/claim-types';
 import { parseFormula } from '@/app/_contexts/parse-formula';
 import { immediateConstraintDependencies } from '@/app/_contexts/immediate-constraint-dependencies';
 import { displayConstraintParse } from '@/app/_contexts/display-constraint-parse';
@@ -32,9 +32,6 @@ type ClaimsContext = {
   //deleteClaim: (claim: Claim) => void;
 }
 
-//A valid claimID must be non-empty, alphanumeric, and not one of the following:
-const forbiddenClaimIDs = new Set(['implies', 'or', 'and', 'not']);
-
 export const ClaimsContext = createContext<ClaimsContext | null>(null);
 
 export function ClaimsContextProvider({ children }: { children: React.ReactNode }) {
@@ -54,10 +51,10 @@ export function ClaimsContextProvider({ children }: { children: React.ReactNode 
       }
       attempts += 1;
     } while (
-      (claimLookup.hasOwnProperty(uniqueID) || forbiddenClaimIDs.has(uniqueID))
+      (claimLookup.hasOwnProperty(uniqueID) || !potentialClaimID(uniqueID))
       && (attempts < 100)
     );
-    if (claimLookup.hasOwnProperty(uniqueID) || forbiddenClaimIDs.has(uniqueID)) {
+    if (claimLookup.hasOwnProperty(uniqueID) || !potentialClaimID(uniqueID)) {
       throw new Error("Unable to generate new claimID");
     }
     return uniqueID;

--- a/frontend/src/app/_contexts/claims-context.tsx
+++ b/frontend/src/app/_contexts/claims-context.tsx
@@ -15,6 +15,7 @@ type ClaimsContext = {
   //other parts of the code can't break the data invariants.
   
   addClaim: ({author, claimType, text}: {author: string, claimType: 'text'|'definition'|'zeroth-order', text: string}) => string;
+  //addClaim returns the claimID assigned to the new claim.
   //To add a claim with definitions, first add the claim without definitions and then
   //add the definitions individually by creating blank definitions and then editing them.
   //This way, definitionClaimIDs[] cannot get duplicates by accident.

--- a/frontend/src/app/_contexts/parse-formula.tsx
+++ b/frontend/src/app/_contexts/parse-formula.tsx
@@ -7,7 +7,8 @@ import {
   AffineExpression,
   AffineEquation,
   ConstraintParse
-} from '@/app/_types/parse-types'; 
+} from '@/app/_types/parse-types';
+import { potentialClaimID } from '@/app/_types/claim-types';
 
 function signlessReal({candidate}: {candidate: string}) : number | null {
   //Tries to parse candidate as a signless real number, returns null if impossible.
@@ -25,11 +26,6 @@ function probabilityValue({candidate}: {candidate: string}) : number | null {
   if ((magnitudeValid && !isNegative) || isZero) {
     return Number(nonNegative);
   } else {return null;}
-}
-
-function isAlphanumeric({candidate}: {candidate: string}) : boolean {
-  //Used for determining if a string is a valid Claim ID.
-  return /^[a-z0-9]+$/i.test(candidate);
 }
 
 function findDepths({formula}: {formula: string}) {
@@ -97,7 +93,7 @@ function parseLogicalFormula({formula}: {formula: string}): LogicalFormula | nul
   const unwrap = attemptUnwrap({trimmedFormula: trimmedFormula, depths: depths});
   if (unwrap !== null) {return parseLogicalFormula({formula: unwrap});}
 
-  if (isAlphanumeric({candidate: trimmedFormula}))
+  if (potentialClaimID({candidate: trimmedFormula}))
     {return {parseType: 'ClaimID' as const, claimID: trimmedFormula} as LogicalFormula;}
 
   const impliesFragments = splitOnAllDepthZeroSubstrings(
@@ -157,7 +153,7 @@ function parseLogicalFormulaWithoutImplies({formula}: {formula: string}):
   const unwrap = attemptUnwrap({trimmedFormula: trimmedFormula, depths: depths});
   if (unwrap !== null) {return parseLogicalFormulaWithoutImplies({formula: unwrap});}
 
-  if (isAlphanumeric({candidate: trimmedFormula}))
+  if (potentialClaimID({candidate: trimmedFormula}))
     {return {parseType: 'ClaimID' as const, claimID: trimmedFormula} as LogicalFormulaWithoutImplies;}
 
   const orFragments = splitOnAllDepthZeroSubstrings(

--- a/frontend/src/app/_types/claim-types.tsx
+++ b/frontend/src/app/_types/claim-types.tsx
@@ -5,7 +5,7 @@ export type TextClaim = {
   author: string;
   claimType: 'text';
   text: string;
-  dependencies: Set<string>; //Deduced from definitionClaimIDs, cannot be specified
+  dependencies: Set<string>;
   definitionClaimIDs: string[];
 };
 
@@ -14,7 +14,7 @@ export type DefinitionClaim = {
   author: string;
   claimType: 'definition';
   text: string;
-  dependencies: Set<string>; //Deduced from definitionClaimIDs, cannot be specified
+  dependencies: Set<string>;
   definitionClaimIDs: string[];
 };
 
@@ -27,8 +27,8 @@ export type ZerothOrderClaim = {
   author: string;
   claimType: 'zeroth-order';
   text: string;
-  dependencies: Set<string>; //Deduced from parse, cannot be specified
-  parse: ConstraintParse | null; //Deduced from text, cannot be specified
+  dependencies: Set<string>;
+  parse: ConstraintParse | null;
 };
 
 export type Claim =

--- a/frontend/src/app/_types/claim-types.tsx
+++ b/frontend/src/app/_types/claim-types.tsx
@@ -5,7 +5,7 @@ export type TextClaim = {
   author: string;
   claimType: 'text';
   text: string;
-  dependencies: Set<string>; //should reflect definitionClaimIDs
+  dependencies: Set<string>; //Deduced from definitionClaimIDs, cannot be specified
   definitionClaimIDs: string[];
 };
 
@@ -14,7 +14,7 @@ export type DefinitionClaim = {
   author: string;
   claimType: 'definition';
   text: string;
-  dependencies: Set<string>; //should reflect definitionClaimIDs
+  dependencies: Set<string>; //Deduced from definitionClaimIDs, cannot be specified
   definitionClaimIDs: string[];
 };
 
@@ -27,8 +27,8 @@ export type ZerothOrderClaim = {
   author: string;
   claimType: 'zeroth-order';
   text: string;
-  dependencies: Set<string>; //should reflect parse
-  parse: ConstraintParse | null;
+  dependencies: Set<string>; //Deduced from parse, cannot be specified
+  parse: ConstraintParse | null; //Deduced from text, cannot be specified
 };
 
 export type Claim =

--- a/frontend/src/app/_types/claim-types.tsx
+++ b/frontend/src/app/_types/claim-types.tsx
@@ -10,7 +10,7 @@ export type TextClaim = {
   author: string;
   claimType: 'text';
   text: string;
-  dependencies: Set<string>; //Can include invalid Claim IDs
+  dependencies: Set<string>; //Must be Set(definitionClaimIDs)
   definitionClaimIDs: string[]; //Can include invalid Claim IDs
 };
 
@@ -19,7 +19,7 @@ export type DefinitionClaim = {
   author: string;
   claimType: 'definition';
   text: string;
-  dependencies: Set<string>; //Can include invalid Claim IDs
+  dependencies: Set<string>; //Must be Set(definitionClaimIDs)
   definitionClaimIDs: string[]; //Can include invalid Claim IDs
 };
 
@@ -32,8 +32,8 @@ export type ZerothOrderClaim = {
   author: string;
   claimType: 'zeroth-order';
   text: string;
-  dependencies: Set<string>; //Can include unrecognized Claim IDs
-  parse: ConstraintParse | null; //Can reference unrecognized Claim IDs
+  dependencies: Set<string>; //Must be immediateConstraintDependencies({parse: parse})
+  parse: ConstraintParse | null; //Must be parseFormula({formula: text}), can reference unrecognized Claim IDs
 };
 
 export type Claim =

--- a/frontend/src/app/_types/claim-types.tsx
+++ b/frontend/src/app/_types/claim-types.tsx
@@ -5,8 +5,8 @@ export type TextClaim = {
   author: string;
   claimType: 'text';
   text: string;
-  dependencies: Set<string>;
-  definitionClaimIDs: string[];
+  dependencies: Set<string>; //Can include invalid Claim IDs
+  definitionClaimIDs: string[]; //Can include invalid Claim IDs
 };
 
 export type DefinitionClaim = {
@@ -14,8 +14,8 @@ export type DefinitionClaim = {
   author: string;
   claimType: 'definition';
   text: string;
-  dependencies: Set<string>;
-  definitionClaimIDs: string[];
+  dependencies: Set<string>; //Can include invalid Claim IDs
+  definitionClaimIDs: string[]; //Can include invalid Claim IDs
 };
 
 export type ClaimWithDefinitions = 
@@ -27,8 +27,8 @@ export type ZerothOrderClaim = {
   author: string;
   claimType: 'zeroth-order';
   text: string;
-  dependencies: Set<string>;
-  parse: ConstraintParse | null;
+  dependencies: Set<string>; //Can include invalid Claim IDs
+  parse: ConstraintParse | null; //Can reference invalid Claim IDs
 };
 
 export type Claim =

--- a/frontend/src/app/_types/claim-types.tsx
+++ b/frontend/src/app/_types/claim-types.tsx
@@ -1,7 +1,12 @@
 import { ConstraintParse } from '@/app/_types/parse-types';
 
+export function potentialClaimID({candidate}: {candidate: string}): boolean {
+  //Specifies whether a string would make a valid Claim ID.
+  return /^[a-z0-9]+$/i.test(candidate) && !['implies', 'or', 'and', 'not'].includes(candidate);
+}
+
 export type TextClaim = {
-  claimID: string;
+  claimID: string; //Must satisfy potentialClaimID
   author: string;
   claimType: 'text';
   text: string;
@@ -10,7 +15,7 @@ export type TextClaim = {
 };
 
 export type DefinitionClaim = {
-  claimID: string;
+  claimID: string; //Must satisfy potentialClaimID
   author: string;
   claimType: 'definition';
   text: string;
@@ -23,12 +28,12 @@ export type ClaimWithDefinitions =
   | DefinitionClaim;
 
 export type ZerothOrderClaim = {
-  claimID: string;
+  claimID: string; //Must satisfy potentialClaimID
   author: string;
   claimType: 'zeroth-order';
   text: string;
-  dependencies: Set<string>; //Can include invalid Claim IDs
-  parse: ConstraintParse | null; //Can reference invalid Claim IDs
+  dependencies: Set<string>; //Can include unrecognized Claim IDs
+  parse: ConstraintParse | null; //Can reference unrecognized Claim IDs
 };
 
 export type Claim =


### PR DESCRIPTION
Let's restrict the interface of claims-context.tsx so that other parts of the code can't break the data invariants.