### PR TITLE
Let's change the ClaimTab dropdown from a Menu to a Popover

### DIFF
--- a/frontend/src/app/_components/claim-box.tsx
+++ b/frontend/src/app/_components/claim-box.tsx
@@ -27,7 +27,7 @@ export function ClaimBox({claimID} : {claimID: string}) {
       ref={setNodeRef}
       {...attributes}
       style={style}
-      className={`flex flex-col ${isDragging ? 'z-30' : ''}`}>
+      className={`flex flex-col ${isDragging ? 'z-40' : ''}`}>
       <div
         className={`flex ${hasDefinitions ? 'rounded-tr-md rounded-tl-md rounded-bl-md' : 'rounded-md'} shadow-xl`}
         {...listeners}>

--- a/frontend/src/app/_components/claim-tab.tsx
+++ b/frontend/src/app/_components/claim-tab.tsx
@@ -38,18 +38,20 @@ export function ClaimTab({claim} : {claim: Claim}) {
           <Popover.Panel className={`absolute w-40 origin-top-right z-20 bg-transparent outline-none rounded-md shadow-xl text-white text-sm font-normal`}>
             <div>
               {acceptsDefinitions ? 
-                <p
+                <Popover.Button
+                  as="p"
                   className="block px-4 py-2 rounded-t-md bg-medium-definition hover:bg-bright-definition"
                   onClick={() => attachBlankDefinition(claim)}>
                   Attach Definition
-                </p> :
+                </Popover.Button> :
                 null
               }
-              <p
+              <Popover.Button
+                as="p"
                 className={`block px-4 py-2 ${acceptsDefinitions ? 'rounded-b-md' : 'rounded-md'} bg-medium-danger hover:bg-bright-danger`}
                 onClick={handleDelete}>
                 Delete Claim
-              </p>
+              </Popover.Button>
             </div>
           </Popover.Panel>
         </Popover>

--- a/frontend/src/app/_components/claim-tab.tsx
+++ b/frontend/src/app/_components/claim-tab.tsx
@@ -35,9 +35,23 @@ export function ClaimTab({claim} : {claim: Claim}) {
           <Popover.Button className={`${claim.claimType === 'text' ? 'bg-medium-text hover:bg-bright-text' : claim.claimType === 'definition' ? 'bg-medium-definition hover:bg-bright-definition' : 'bg-medium-zeroth-order hover:bg-bright-zeroth-order'} h-full w-14 p-2 rounded-l-md`}>
             <p className="text-white text-sm truncate">{claim.claimID}</p>
           </Popover.Button>
-          <Popover.Panel className={`absolute w-40 origin-top-right z-20 bg-bright-neutral outline-none rounded-md shadow-xl text-white text-sm font-normal`}>
+          <Popover.Panel className={`absolute w-96 origin-top-right z-20 bg-bright-neutral outline-none rounded-md shadow-xl text-white text-sm font-normal`}>
             <div>
               <p className="px-4 py-2">Conditioning:</p>
+              <div className="container mx-auto flex justify-between items-center">
+                <Popover.Button
+                  className="block px-4 py-2 bg-bright-neutral hover:bg-medium-neutral">
+                  False
+                </Popover.Button>
+                <Popover.Button
+                  className="block px-4 py-2 bg-bright-neutral hover:bg-medium-neutral">
+                  None
+                </Popover.Button>
+                <Popover.Button
+                  className="block px-4 py-2 bg-bright-neutral hover:bg-medium-neutral">
+                  True
+                </Popover.Button>
+              </div>
               {acceptsDefinitions ? 
                 <Popover.Button
                   as="p"

--- a/frontend/src/app/_components/claim-tab.tsx
+++ b/frontend/src/app/_components/claim-tab.tsx
@@ -35,10 +35,10 @@ export function ClaimTab({claim} : {claim: Claim}) {
           <Popover.Button className={`${claim.claimType === 'text' ? 'bg-medium-text hover:bg-bright-text' : claim.claimType === 'definition' ? 'bg-medium-definition hover:bg-bright-definition' : 'bg-medium-zeroth-order hover:bg-bright-zeroth-order'} h-full w-14 p-2 rounded-l-md`}>
             <p className="text-white text-sm truncate">{claim.claimID}</p>
           </Popover.Button>
-          <Popover.Panel className={`absolute w-96 origin-top-right z-20 bg-bright-neutral outline-none rounded-md shadow-xl text-white text-sm font-normal`}>
+          <Popover.Panel className={`absolute origin-top-right z-20 bg-bright-neutral outline-none rounded-md shadow-xl text-white text-sm font-normal`}>
             <div>
               <p className="px-4 py-2">Conditioning:</p>
-              <div className="container mx-auto flex justify-between items-center">
+              <div className="container mx-auto flex items-center">
                 <Popover.Button
                   className="block px-4 py-2 bg-bright-neutral hover:bg-medium-neutral">
                   False

--- a/frontend/src/app/_components/claim-tab.tsx
+++ b/frontend/src/app/_components/claim-tab.tsx
@@ -40,15 +40,15 @@ export function ClaimTab({claim} : {claim: Claim}) {
               <p className="px-4 py-2">Conditioning:</p>
               <div className="container mx-auto flex items-center">
                 <Popover.Button
-                  className="block px-4 py-2 hover:bg-medium-neutral">
+                  className={`block px-4 py-2 ${claim.claimType === 'text' : (claim.conditioning === false ? 'bg-bright-text' : 'hover:bg-medium-text') : claim.claimType === 'definition' ? (claim.conditioning === false ? 'bg-bright-definition' : 'hover:bg-medium-definition') : (claim.conditioning === false ? 'bg-bright-zeroth-order' : 'hover:bg-medium-zeroth-order')}`}>
                   False
                 </Popover.Button>
                 <Popover.Button
-                  className="block px-4 py-2 hover:bg-medium-neutral">
+                  className={`block px-4 py-2 ${claim.claimType === 'text' : (claim.conditioning === null ? 'bg-bright-text' : 'hover:bg-medium-text') : claim.claimType === 'definition' ? (claim.conditioning === null ? 'bg-bright-definition' : 'hover:bg-medium-definition') : (claim.conditioning === null ? 'bg-bright-zeroth-order' : 'hover:bg-medium-zeroth-order')}`}>
                   None
                 </Popover.Button>
                 <Popover.Button
-                  className="block px-4 py-2 hover:bg-medium-neutral">
+                  className={`block px-4 py-2 ${claim.claimType === 'text' : (claim.conditioning === true ? 'bg-bright-text' : 'hover:bg-medium-text') : claim.claimType === 'definition' ? (claim.conditioning === true ? 'bg-bright-definition' : 'hover:bg-medium-definition') : (claim.conditioning === true ? 'bg-bright-zeroth-order' : 'hover:bg-medium-zeroth-order')}`}>
                   True
                 </Popover.Button>
               </div>

--- a/frontend/src/app/_components/claim-tab.tsx
+++ b/frontend/src/app/_components/claim-tab.tsx
@@ -35,20 +35,20 @@ export function ClaimTab({claim} : {claim: Claim}) {
           <Popover.Button className={`${claim.claimType === 'text' ? 'bg-medium-text hover:bg-bright-text' : claim.claimType === 'definition' ? 'bg-medium-definition hover:bg-bright-definition' : 'bg-medium-zeroth-order hover:bg-bright-zeroth-order'} h-full w-14 p-2 rounded-l-md`}>
             <p className="text-white text-sm truncate">{claim.claimID}</p>
           </Popover.Button>
-          <Popover.Panel className={`absolute origin-top-right z-20 bg-bright-neutral outline-none rounded-md shadow-xl text-white text-sm font-normal`}>
+          <Popover.Panel className={`absolute origin-top-right z-20 ${claim.claimType === 'text' ? 'bg-dark-text' : claim.claimType === 'definition' ? 'bg-dark-definition' : 'bg-dark-zeroth-order'} outline-none rounded-md shadow-xl text-white text-sm font-normal`}>
             <div>
               <p className="px-4 py-2">Conditioning:</p>
               <div className="container mx-auto flex items-center">
                 <Popover.Button
-                  className="block px-4 py-2 bg-bright-neutral hover:bg-medium-neutral">
+                  className="block px-4 py-2 hover:bg-medium-neutral">
                   False
                 </Popover.Button>
                 <Popover.Button
-                  className="block px-4 py-2 bg-bright-neutral hover:bg-medium-neutral">
+                  className="block px-4 py-2 hover:bg-medium-neutral">
                   None
                 </Popover.Button>
                 <Popover.Button
-                  className="block px-4 py-2 bg-bright-neutral hover:bg-medium-neutral">
+                  className="block px-4 py-2 hover:bg-medium-neutral">
                   True
                 </Popover.Button>
               </div>

--- a/frontend/src/app/_components/claim-tab.tsx
+++ b/frontend/src/app/_components/claim-tab.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Menu } from '@headlessui/react';
+import { Popover } from '@headlessui/react';
 import { Claim } from '@/app/_types/claim-types';
 import { useClaimsContext } from '@/app/_contexts/claims-context';
 import { DeletionDialog } from '@/app/_components/deletion-dialog';
@@ -31,36 +31,28 @@ export function ClaimTab({claim} : {claim: Claim}) {
   return (
     <>
       <div className="relative">
-        <Menu>
-          <Menu.Button className={`${claim.claimType === 'text' ? 'bg-medium-text hover:bg-bright-text' : claim.claimType === 'definition' ? 'bg-medium-definition hover:bg-bright-definition' : 'bg-medium-zeroth-order hover:bg-bright-zeroth-order'} h-full w-14 p-2 rounded-l-md`}>
+        <Popover>
+          <Popover.Button className={`${claim.claimType === 'text' ? 'bg-medium-text hover:bg-bright-text' : claim.claimType === 'definition' ? 'bg-medium-definition hover:bg-bright-definition' : 'bg-medium-zeroth-order hover:bg-bright-zeroth-order'} h-full w-14 p-2 rounded-l-md`}>
             <p className="text-white text-sm truncate">{claim.claimID}</p>
-          </Menu.Button>
-          <Menu.Items className={`absolute w-40 origin-top-right z-20 bg-transparent outline-none rounded-md shadow-xl text-white text-sm font-normal`}>
+          </Popover.Button>
+          <Popover.Panel className={`absolute w-40 origin-top-right z-20 bg-transparent outline-none rounded-md shadow-xl text-white text-sm font-normal`}>
             <div>
               {acceptsDefinitions ? 
-                <Menu.Item>
-                  {({ active }) => (
-                    <a
-                      className={`block px-4 py-2 rounded-t-md ${active ? 'bg-bright-definition' : 'bg-medium-definition'}`}
-                      onClick={() => attachBlankDefinition(claim)}>
-                      Attach Definition
-                    </a>
-                  )}
-                </Menu.Item> :
+                <p
+                  className={`block px-4 py-2 rounded-t-md ${false ? 'bg-bright-definition' : 'bg-medium-definition'}`}
+                  onClick={() => attachBlankDefinition(claim)}>
+                  Attach Definition
+                </p> :
                 null
               }
-              <Menu.Item>
-                {({ active }) => (
-                  <a
-                    className={`block px-4 py-2 ${acceptsDefinitions ? 'rounded-b-md' : 'rounded-md'} ${active ? 'bg-bright-danger' : 'bg-medium-danger'}`}
-                    onClick={handleDelete}>
-                    Delete Claim
-                  </a>
-                )}
-              </Menu.Item>
+              <p
+                className={`block px-4 py-2 ${acceptsDefinitions ? 'rounded-b-md' : 'rounded-md'} ${false ? 'bg-bright-danger' : 'bg-medium-danger'}`}
+                onClick={handleDelete}>
+                Delete Claim
+              </p>
             </div>
-          </Menu.Items>
-        </Menu>
+          </Popover.Panel>
+        </Popover>
       </div>
       <DeletionDialog
         dialogOpen={dialogOpen}

--- a/frontend/src/app/_components/claim-tab.tsx
+++ b/frontend/src/app/_components/claim-tab.tsx
@@ -39,14 +39,14 @@ export function ClaimTab({claim} : {claim: Claim}) {
             <div>
               {acceptsDefinitions ? 
                 <p
-                  className={`block px-4 py-2 rounded-t-md ${false ? 'bg-bright-definition' : 'bg-medium-definition'}`}
+                  className="block px-4 py-2 rounded-t-md bg-medium-definition hover:bg-bright-definition"
                   onClick={() => attachBlankDefinition(claim)}>
                   Attach Definition
                 </p> :
                 null
               }
               <p
-                className={`block px-4 py-2 ${acceptsDefinitions ? 'rounded-b-md' : 'rounded-md'} ${false ? 'bg-bright-danger' : 'bg-medium-danger'}`}
+                className={`block px-4 py-2 ${acceptsDefinitions ? 'rounded-b-md' : 'rounded-md'} bg-medium-danger hover:bg-bright-danger`}
                 onClick={handleDelete}>
                 Delete Claim
               </p>

--- a/frontend/src/app/_components/claim-tab.tsx
+++ b/frontend/src/app/_components/claim-tab.tsx
@@ -35,18 +35,18 @@ export function ClaimTab({claim} : {claim: Claim}) {
           <Popover.Button className={`${claim.claimType === 'text' ? 'bg-medium-text hover:bg-bright-text' : claim.claimType === 'definition' ? 'bg-medium-definition hover:bg-bright-definition' : 'bg-medium-zeroth-order hover:bg-bright-zeroth-order'} h-full w-14 p-2 rounded-l-md`}>
             <p className="text-white text-sm truncate">{claim.claimID}</p>
           </Popover.Button>
-          <Popover.Panel className={`absolute w-40 origin-top-right z-20 bg-dark-neutral outline-none rounded-md shadow-xl text-white text-sm font-normal`}>
+          <Popover.Panel className={`absolute w-40 origin-top-right z-20 bg-bright-neutral outline-none rounded-md shadow-xl text-white text-sm font-normal`}>
             <div>
+              <p className="px-4 py-2">Conditioning:</p>
               {acceptsDefinitions ? 
                 <Popover.Button
                   as="p"
-                  className="block px-4 py-2 rounded-t-md bg-medium-definition hover:bg-bright-definition"
+                  className="block px-4 py-2 bg-medium-definition hover:bg-bright-definition"
                   onClick={() => attachBlankDefinition(claim)}>
                   Attach Definition
                 </Popover.Button> :
                 null
               }
-              <p className="px-4 py-2">Conditioning:</p>
               <Popover.Button
                 as="p"
                 className="block px-4 py-2 rounded-b-md bg-medium-danger hover:bg-bright-danger"

--- a/frontend/src/app/_components/claim-tab.tsx
+++ b/frontend/src/app/_components/claim-tab.tsx
@@ -40,15 +40,15 @@ export function ClaimTab({claim} : {claim: Claim}) {
               <p className="px-4 py-2">Conditioning:</p>
               <div className="container mx-auto flex items-center">
                 <Popover.Button
-                  className={`block px-4 py-2 ${claim.claimType === 'text' : (claim.conditioning === false ? 'bg-bright-text' : 'hover:bg-medium-text') : claim.claimType === 'definition' ? (claim.conditioning === false ? 'bg-bright-definition' : 'hover:bg-medium-definition') : (claim.conditioning === false ? 'bg-bright-zeroth-order' : 'hover:bg-medium-zeroth-order')}`}>
+                  className={`block px-4 py-2 ${claim.claimType === 'text' ? (claim.conditioning === false ? 'bg-bright-text' : 'hover:bg-medium-text') : claim.claimType === 'definition' ? (claim.conditioning === false ? 'bg-bright-definition' : 'hover:bg-medium-definition') : (claim.conditioning === false ? 'bg-bright-zeroth-order' : 'hover:bg-medium-zeroth-order')}`}>
                   False
                 </Popover.Button>
                 <Popover.Button
-                  className={`block px-4 py-2 ${claim.claimType === 'text' : (claim.conditioning === null ? 'bg-bright-text' : 'hover:bg-medium-text') : claim.claimType === 'definition' ? (claim.conditioning === null ? 'bg-bright-definition' : 'hover:bg-medium-definition') : (claim.conditioning === null ? 'bg-bright-zeroth-order' : 'hover:bg-medium-zeroth-order')}`}>
+                  className={`block px-4 py-2 ${claim.claimType === 'text' ? (claim.conditioning === null ? 'bg-bright-text' : 'hover:bg-medium-text') : claim.claimType === 'definition' ? (claim.conditioning === null ? 'bg-bright-definition' : 'hover:bg-medium-definition') : (claim.conditioning === null ? 'bg-bright-zeroth-order' : 'hover:bg-medium-zeroth-order')}`}>
                   None
                 </Popover.Button>
                 <Popover.Button
-                  className={`block px-4 py-2 ${claim.claimType === 'text' : (claim.conditioning === true ? 'bg-bright-text' : 'hover:bg-medium-text') : claim.claimType === 'definition' ? (claim.conditioning === true ? 'bg-bright-definition' : 'hover:bg-medium-definition') : (claim.conditioning === true ? 'bg-bright-zeroth-order' : 'hover:bg-medium-zeroth-order')}`}>
+                  className={`block px-4 py-2 ${claim.claimType === 'text' ? (claim.conditioning === true ? 'bg-bright-text' : 'hover:bg-medium-text') : claim.claimType === 'definition' ? (claim.conditioning === true ? 'bg-bright-definition' : 'hover:bg-medium-definition') : (claim.conditioning === true ? 'bg-bright-zeroth-order' : 'hover:bg-medium-zeroth-order')}`}>
                   True
                 </Popover.Button>
               </div>

--- a/frontend/src/app/_components/claim-tab.tsx
+++ b/frontend/src/app/_components/claim-tab.tsx
@@ -35,7 +35,7 @@ export function ClaimTab({claim} : {claim: Claim}) {
           <Popover.Button className={`${claim.claimType === 'text' ? 'bg-medium-text hover:bg-bright-text' : claim.claimType === 'definition' ? 'bg-medium-definition hover:bg-bright-definition' : 'bg-medium-zeroth-order hover:bg-bright-zeroth-order'} h-full w-14 p-2 rounded-l-md`}>
             <p className="text-white text-sm truncate">{claim.claimID}</p>
           </Popover.Button>
-          <Popover.Panel className={`absolute w-40 origin-top-right z-20 bg-transparent outline-none rounded-md shadow-xl text-white text-sm font-normal`}>
+          <Popover.Panel className={`absolute w-40 origin-top-right z-20 bg-dark-neutral outline-none rounded-md shadow-xl text-white text-sm font-normal`}>
             <div>
               {acceptsDefinitions ? 
                 <Popover.Button
@@ -46,9 +46,10 @@ export function ClaimTab({claim} : {claim: Claim}) {
                 </Popover.Button> :
                 null
               }
+              <p className="px-4 py-2">Conditioning:</p>
               <Popover.Button
                 as="p"
-                className={`block px-4 py-2 ${acceptsDefinitions ? 'rounded-b-md' : 'rounded-md'} bg-medium-danger hover:bg-bright-danger`}
+                className="block px-4 py-2 rounded-b-md bg-medium-danger hover:bg-bright-danger"
                 onClick={handleDelete}>
                 Delete Claim
               </Popover.Button>

--- a/frontend/src/app/_components/definition-list.tsx
+++ b/frontend/src/app/_components/definition-list.tsx
@@ -41,7 +41,7 @@ function DefinitionBox({initialDefinitionClaimID, final, parentClaim}:
       {...attributes}
       {...listeners}
       style={style}
-      className={`flex border-t border-bright-neutral ${isDragging ? 'z-30' : 'z-0'}`}>
+      className={`flex border-t border-bright-neutral ${isDragging ? 'z-40' : 'z-0'}`}>
       <input
         type="text"
         value={definitionClaimID}

--- a/frontend/src/app/_components/new-claim-button.tsx
+++ b/frontend/src/app/_components/new-claim-button.tsx
@@ -16,7 +16,7 @@ export function NewClaimButton() {
               : (<p className="px-2 py-1 rounded-md bg-transparent hover:bg-medium-neutral">New Claim</p>) 
           }
         </Menu.Button>
-        <Menu.Items className="absolute w-40 origin-top-right z-20 bg-transparent outline-none rounded-md shadow-xl text-sm font-normal">
+        <Menu.Items className="absolute w-40 origin-top-right z-30 bg-transparent outline-none rounded-md shadow-xl text-sm font-normal">
           <div>
             <Menu.Item>
               {({ active }) => (


### PR DESCRIPTION
HeadlessUI's documentation says that a Popover is better for more complicated dropdown user interfaces than a Menu.